### PR TITLE
Updates 218

### DIFF
--- a/src/dialogue/class.dialogue-db.test.ts
+++ b/src/dialogue/class.dialogue-db.test.ts
@@ -4,6 +4,7 @@ import { Memory } from "./class.memory";
 import { Message } from "./class.message";
 import { createDialogue } from "@/methods/createDialogue";
 import { getDialogue } from "@/methods/getDialogue";
+import { getOrCreateDialogue } from "@/methods/getOrCreateDialogue";
 import { createMemory } from "@/methods/createMemory";
 import { getMemory } from "@/methods/getMemory";
 import {
@@ -11,22 +12,37 @@ import {
   searchMessages,
   searchMemories,
 } from "@/methods/search";
+import * as dialogueApi from "@/api/dialogue";
+import * as memoryApi from "@/api/memory";
 import { SettingsContainer } from "@/settings/class.SettingsContainer";
 
 jest.mock("@/methods/createDialogue");
 jest.mock("@/methods/getDialogue");
+jest.mock("@/methods/getOrCreateDialogue");
 jest.mock("@/methods/createMemory");
 jest.mock("@/methods/getMemory");
 jest.mock("@/methods/search");
+jest.mock("@/methods/listDialogues");
+jest.mock("@/api/dialogue", () => ({
+  remove: jest.fn(),
+}));
+jest.mock("@/api/memory", () => ({
+  list: jest.fn(),
+  remove: jest.fn(),
+}));
 
 describe("DialogueDB", () => {
   const createDialogueMock = createDialogue as jest.Mock;
   const getDialogueMock = getDialogue as jest.Mock;
+  const getOrCreateDialogueMock = getOrCreateDialogue as jest.Mock;
   const createMemoryMock = createMemory as jest.Mock;
   const getMemoryMock = getMemory as jest.Mock;
   const searchDialoguesMock = searchDialogues as jest.Mock;
   const searchMessagesMock = searchMessages as jest.Mock;
   const searchMemoriesMock = searchMemories as jest.Mock;
+  const dialogueRemoveMock = dialogueApi.remove as jest.Mock;
+  const memoryListMock = memoryApi.list as jest.Mock;
+  const memoryRemoveMock = memoryApi.remove as jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -345,6 +361,103 @@ describe("DialogueDB", () => {
       await db.searchMemories("query");
 
       expect(searchMemoriesMock).toHaveBeenCalledWith("query", {}, settings);
+    });
+  });
+
+  describe("getOrCreateDialogue", () => {
+    it("should call getOrCreateDialogue with input", async () => {
+      const mockDialogue = { id: "test-id" } as unknown as Dialogue;
+      getOrCreateDialogueMock.mockResolvedValueOnce(mockDialogue);
+
+      const db = new DialogueDB();
+      const result = await db.getOrCreateDialogue({ id: "test-id" });
+
+      expect(getOrCreateDialogueMock).toHaveBeenCalledWith(
+        { id: "test-id" },
+        expect.any(SettingsContainer)
+      );
+      expect(result).toBe(mockDialogue);
+    });
+
+    it("should call getOrCreateDialogue without input", async () => {
+      const mockDialogue = { id: "new-id" } as unknown as Dialogue;
+      getOrCreateDialogueMock.mockResolvedValueOnce(mockDialogue);
+
+      const db = new DialogueDB();
+      const result = await db.getOrCreateDialogue();
+
+      expect(getOrCreateDialogueMock).toHaveBeenCalledWith(
+        undefined,
+        expect.any(SettingsContainer)
+      );
+      expect(result).toBe(mockDialogue);
+    });
+  });
+
+  describe("deleteDialogue", () => {
+    it("should delete dialogue by id", async () => {
+      dialogueRemoveMock.mockResolvedValueOnce(undefined);
+
+      const db = new DialogueDB();
+      await db.deleteDialogue("dialogue-123");
+
+      expect(dialogueRemoveMock).toHaveBeenCalledWith(
+        { id: "dialogue-123" },
+        expect.any(SettingsContainer)
+      );
+    });
+
+    it("should delete dialogue with namespace", async () => {
+      dialogueRemoveMock.mockResolvedValueOnce(undefined);
+
+      const db = new DialogueDB();
+      await db.deleteDialogue("dialogue-123", "my-ns");
+
+      expect(dialogueRemoveMock).toHaveBeenCalledWith(
+        { id: "dialogue-123", namespace: "my-ns" },
+        expect.any(SettingsContainer)
+      );
+    });
+  });
+
+  describe("listMemories", () => {
+    it("should list memories with default empty input", async () => {
+      memoryListMock.mockResolvedValueOnce({ items: [], next: undefined });
+
+      const db = new DialogueDB();
+      const result = await db.listMemories();
+
+      expect(memoryListMock).toHaveBeenCalledWith(
+        {},
+        expect.any(SettingsContainer)
+      );
+      expect(result.items).toEqual([]);
+    });
+
+    it("should list memories with filters", async () => {
+      memoryListMock.mockResolvedValueOnce({ items: [{ id: "m1" }] });
+
+      const db = new DialogueDB();
+      await db.listMemories({ limit: 10, namespace: "my-ns" });
+
+      expect(memoryListMock).toHaveBeenCalledWith(
+        { limit: 10, namespace: "my-ns" },
+        expect.any(SettingsContainer)
+      );
+    });
+  });
+
+  describe("deleteMemory", () => {
+    it("should delete memory by id", async () => {
+      memoryRemoveMock.mockResolvedValueOnce(undefined);
+
+      const db = new DialogueDB();
+      await db.deleteMemory("memory-123");
+
+      expect(memoryRemoveMock).toHaveBeenCalledWith(
+        { id: "memory-123" },
+        expect.any(SettingsContainer)
+      );
     });
   });
 

--- a/src/dialogue/class.dialogue-db.ts
+++ b/src/dialogue/class.dialogue-db.ts
@@ -6,9 +6,15 @@ import {
 import { Dialogue } from "./class.dialogue";
 import { Memory } from "./class.memory";
 import { Message } from "./class.message";
-import { CreateDialogueInput, CreateMemoryInput } from "@/types";
+import {
+  CreateDialogueInput,
+  CreateMemoryInput,
+  DeleteDialogueInput,
+  ListMemoriesFilters,
+} from "@/types";
 import { createDialogue } from "@/methods/createDialogue";
 import { getDialogue } from "@/methods/getDialogue";
+import { getOrCreateDialogue } from "@/methods/getOrCreateDialogue";
 import { createMemory } from "@/methods/createMemory";
 import { getMemory } from "@/methods/getMemory";
 import {
@@ -18,6 +24,8 @@ import {
   SearchOptions,
 } from "@/methods/search";
 import { listDialogues } from "@/methods/listDialogues";
+import * as dialogueApi from "@/api/dialogue";
+import * as memoryApi from "@/api/memory";
 
 export class DialogueDB {
   #settings: SettingsContainer;
@@ -41,10 +49,28 @@ export class DialogueDB {
   }
 
   /**
+   * Get an existing dialogue by ID, or create a new one
+   */
+  getOrCreateDialogue(
+    input?: { id?: string; namespace?: string; threadOf?: string }
+  ): Promise<Dialogue> {
+    return getOrCreateDialogue(input, this.#settings);
+  }
+
+  /**
    * List dialogues
    */
   listDialogues(input: Parameters<typeof listDialogues>[0] = {}) {
     return listDialogues(input, this.#settings);
+  }
+
+  /**
+   * Delete a dialogue by ID
+   */
+  async deleteDialogue(id: string, namespace?: string): Promise<void> {
+    const input: DeleteDialogueInput = { id };
+    if (namespace) input.namespace = namespace;
+    return dialogueApi.remove(input, this.#settings);
   }
 
   /**
@@ -59,6 +85,20 @@ export class DialogueDB {
    */
   getMemory(id: string, namespace?: string): Promise<Memory | null> {
     return getMemory({ id, namespace }, this.#settings);
+  }
+
+  /**
+   * List memories
+   */
+  listMemories(input: ListMemoriesFilters = {}) {
+    return memoryApi.list(input, this.#settings);
+  }
+
+  /**
+   * Delete a memory by id
+   */
+  async deleteMemory(id: string): Promise<void> {
+    return memoryApi.remove({ id }, this.#settings);
   }
 
   /**

--- a/src/dialogue/class.dialogue-db.ts
+++ b/src/dialogue/class.dialogue-db.ts
@@ -43,7 +43,7 @@ export class DialogueDB {
   /**
    * List dialogues
    */
-  listDialogues(input: Parameters<typeof listDialogues>[0]) {
+  listDialogues(input: Parameters<typeof listDialogues>[0] = {}) {
     return listDialogues(input, this.#settings);
   }
 

--- a/src/dialogue/class.dialogue-db.ts
+++ b/src/dialogue/class.dialogue-db.ts
@@ -51,9 +51,11 @@ export class DialogueDB {
   /**
    * Get an existing dialogue by ID, or create a new one
    */
-  getOrCreateDialogue(
-    input?: { id?: string; namespace?: string; threadOf?: string }
-  ): Promise<Dialogue> {
+  getOrCreateDialogue(input?: {
+    id?: string;
+    namespace?: string;
+    threadOf?: string;
+  }): Promise<Dialogue> {
     return getOrCreateDialogue(input, this.#settings);
   }
 

--- a/src/dialogue/class.dialogue.test.ts
+++ b/src/dialogue/class.dialogue.test.ts
@@ -198,6 +198,19 @@ describe("Dialogue", () => {
       expect(dialogue.metadata.key).toBe("value");
     });
 
+    it("metadata getter returns deep clone - nested mutation does not affect internal metadata", () => {
+      const dialogue = new Dialogue(
+        createMockDialogue({
+          metadata: { nested: { deep: "original" } } as any,
+        })
+      );
+
+      const retrieved = dialogue.metadata as any;
+      retrieved.nested.deep = "mutated";
+
+      expect((dialogue.metadata as any).nested.deep).toBe("original");
+    });
+
     it("deep clones state from constructor input", () => {
       const originalState = { nested: { count: 5 } };
       const dialogue = new Dialogue(
@@ -1105,6 +1118,31 @@ describe("Dialogue", () => {
       expect(json.totalMessages).toBe(10);
       expect(json.threadCount).toBe(2);
       expect(json.lastMessageCreated).toBe("2024-07-01T00:00:00.000Z");
+    });
+
+    it("toJSON returns copies - mutating result does not affect internal state", () => {
+      const dialogue = new Dialogue(
+        createMockDialogue({
+          state: { key: "original" },
+          metadata: { key: "original" },
+          tags: ["original"],
+          messages: [createMockMessage()],
+        })
+      );
+
+      const json = dialogue.toJSON();
+
+      // Mutate all the returned objects
+      (json.state as any).key = "mutated";
+      (json.metadata as any).key = "mutated";
+      json.tags.push("mutated");
+      json.messages.length = 0;
+
+      // Internal state should be unchanged
+      expect(dialogue.state).toEqual({ key: "original" });
+      expect(dialogue.metadata).toEqual({ key: "original" });
+      expect(dialogue.tags).toEqual(["original"]);
+      expect(dialogue.messages.length).toBe(1);
     });
 
     it("inspect.custom returns same as toJSON", () => {

--- a/src/dialogue/class.dialogue.ts
+++ b/src/dialogue/class.dialogue.ts
@@ -175,7 +175,7 @@ export class Dialogue {
   }
 
   get metadata(): Readonly<Record<string, any>> {
-    return { ...this.#metadata };
+    return structuredClone(this.#metadata);
   }
 
   get created(): string {
@@ -464,10 +464,10 @@ export class Dialogue {
       ...(this.#lastMessageCreated !== undefined && {
         lastMessageCreated: this.#lastMessageCreated,
       }),
-      metadata: this.#metadata,
-      state: this.#state,
-      tags: this.#tags,
-      messages: this.#messages,
+      metadata: structuredClone(this.#metadata),
+      state: structuredClone(this.#state),
+      tags: [...this.#tags],
+      messages: [...this.#messages],
       created: this.#created,
       modified: this.#modified,
     };

--- a/src/dialogue/class.memory.test.ts
+++ b/src/dialogue/class.memory.test.ts
@@ -156,7 +156,6 @@ describe("Memory", () => {
       expect(memory.tags).toEqual(["tag1", "tag2"]);
     });
 
-    // BUG TEST: tags getter returns direct reference
     it("tags getter returns clone - external mutation does not affect internal tags", () => {
       const memory = new Memory(createMockMemory({ tags: ["original"] }));
 
@@ -169,7 +168,6 @@ describe("Memory", () => {
       expect(memory.isDirty).toBe(false);
     });
 
-    // BUG TEST: value getter returns shallow copy for nested objects
     it("value getter returns deep clone - nested mutation does not affect internal value", () => {
       const memory = new Memory(
         createMockMemory({
@@ -409,6 +407,27 @@ describe("Memory", () => {
 
       expect(parsed.id).toBe(id);
       expect(parsed.value).toBe("test");
+    });
+
+    it("toJSON returns copies - mutating result does not affect internal state", () => {
+      const memory = new Memory(
+        createMockMemory({
+          value: { nested: "original" },
+          metadata: { key: "original" },
+          tags: ["original"],
+        })
+      );
+
+      const json = memory.toJSON();
+
+      (json.value as any).nested = "mutated";
+      (json.metadata as any).key = "mutated";
+      json.tags.push("mutated");
+
+      expect((memory.value as any).nested).toBe("original");
+      expect(memory.metadata.key).toBe("original");
+      expect(memory.tags).toEqual(["original"]);
+      expect(memory.isDirty).toBe(false);
     });
 
     it("inspect.custom returns same as toJSON", () => {

--- a/src/dialogue/class.memory.ts
+++ b/src/dialogue/class.memory.ts
@@ -178,9 +178,12 @@ export class Memory {
       ...(this.#description !== undefined && {
         description: this.#description,
       }),
-      value: this.#value,
-      metadata: this.#metadata,
-      tags: this.#tags,
+      value:
+        typeof this.#value === "object" && this.#value !== null
+          ? structuredClone(this.#value)
+          : this.#value,
+      metadata: structuredClone(this.#metadata),
+      tags: [...this.#tags],
       created: this.#created,
       modified: this.#modified,
     };

--- a/src/dialogue/class.message.test.ts
+++ b/src/dialogue/class.message.test.ts
@@ -177,7 +177,6 @@ describe("Message", () => {
       expect(message.tags).toEqual(["tag1", "tag2"]);
     });
 
-    // BUG TEST: tags getter returns direct reference
     it("tags getter returns clone - external mutation does not affect internal tags", () => {
       const message = new Message(
         dialogueId,
@@ -401,6 +400,25 @@ describe("Message", () => {
 
       const json = message.toJSON();
       expect(json).not.toHaveProperty("name");
+    });
+
+    it("toJSON returns copies - mutating result does not affect internal state", () => {
+      const message = new Message(
+        dialogueId,
+        createMockMessage({
+          metadata: { key: "original" },
+          tags: ["original"],
+        })
+      );
+
+      const json = message.toJSON();
+
+      (json.metadata as any).key = "mutated";
+      (json.tags as any).push("mutated");
+
+      expect(message.metadata!.key).toBe("original");
+      expect(message.tags).toEqual(["original"]);
+      expect(message.isDirty).toBe(false);
     });
 
     it("inspect.custom returns same as toJSON", () => {

--- a/src/dialogue/class.message.ts
+++ b/src/dialogue/class.message.ts
@@ -169,8 +169,10 @@ export class Message {
       content: this.#content,
       created: this.#created,
       ...(this.#name !== undefined && { name: this.#name }),
-      ...(this.#metadata !== undefined && { metadata: this.#metadata }),
-      ...(this.#tags.length > 0 && { tags: this.#tags }),
+      ...(this.#metadata !== undefined && {
+        metadata: structuredClone(this.#metadata),
+      }),
+      ...(this.#tags.length > 0 && { tags: [...this.#tags] }),
     };
   }
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -17,4 +17,10 @@ describe("dialogue", () => {
     expect(typeof modules.settings).toBe("object");
     expect(typeof modules.DialogueDB).toBe("function");
   });
+
+  it("exports Dialogue, Message, and Memory classes", () => {
+    expect(typeof modules.Dialogue).toBe("function");
+    expect(typeof modules.Message).toBe("function");
+    expect(typeof modules.Memory).toBe("function");
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,39 @@ import { createConfig } from "./settings/createConfig";
 export { DialogueDBError } from "./errors";
 export type { ErrorType } from "./utils/request";
 
-// dialogue class/utils
+// classes
 import { DialogueDB } from "./dialogue/class.dialogue-db";
+import { Dialogue } from "./dialogue/class.dialogue";
+import { Message } from "./dialogue/class.message";
+import { Memory } from "./dialogue/class.memory";
+
+// types
+export type {
+  IDialogue,
+  CreateDialogueInput,
+  UpdateDialogueInput,
+  GetDialogueInput,
+  ListDialogueFilters,
+} from "./types/dialogue";
+
+export type {
+  IMessage,
+  MessageContent,
+  CreateMessageInput,
+  ListMessageFilters,
+} from "./types/message";
+
+export type {
+  IMemory,
+  CreateMemoryInput,
+  ListMemoriesFilters,
+} from "./types/memory";
+
+export type { ListResponse } from "./types/utils";
+
+export type { SearchFilterOptions, SearchOptions } from "./api/search";
+
+export type { Settings } from "./settings/class.SettingsContainer";
 
 // api things
 import * as dialogueApi from "./api/dialogue";
@@ -54,6 +85,9 @@ export {
   settings,
   createConfig,
 
-  // expose the class
+  // classes
   DialogueDB,
+  Dialogue,
+  Message,
+  Memory,
 };


### PR DESCRIPTION
API and Class Enhancements:

Added new methods to DialogueDB:

- getOrCreateDialogue to fetch or create a dialogue.
- deleteDialogue to remove a dialogue by ID (optionally with namespace).
- listMemories and deleteMemory for memory management.
- These methods are fully tested with new test cases.
- Exported Dialogue, Message, and Memory classes and a wide range of related types from the main entry point (src/index.ts), making them available for external consumers.

Immutability and Data Protection:

Ensured that getters and toJSON methods in Dialogue, Message, and Memory return deep copies of internal state, metadata, tags, and messages. This prevents external mutation of internal data structures.