### PR TITLE
Update npm publish workflow with permissions and failure handling

### DIFF
--- a/.github/workflows/publish-npm-release.yml
+++ b/.github/workflows/publish-npm-release.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   id-token: write
-  contents: read
+  contents: write
   
 jobs:   
   publish-npm:
@@ -34,6 +34,7 @@ jobs:
         run: npm pack --dry-run
 
       - name: Publish Main/Beta Package version
+        id: npm-publish
         run: |
           version=$(node -p "require('./package.json').version")
           if [[ "$version" == *"beta"* ]]; then
@@ -45,3 +46,35 @@ jobs:
           fi
           
           echo "✅ Package published successfully!"
+
+      - name: Revert release to draft on failure
+        if: failure() && github.event_name == 'release'
+        run: |
+          RELEASE_ID=$(jq -r .release.id "$GITHUB_EVENT_PATH")
+          ORIGINAL_BODY=$(jq -r .release.body "$GITHUB_EVENT_PATH")
+          echo "Publishing failed. Reverting release ID $RELEASE_ID back to draft status..."
+          # Create warning banner and combine with original body
+          cat > release_body.txt <<'EOF'
+          > [!WARNING]
+          > **Release Publishing Failed**
+          > This release has been automatically reverted to draft status because the package failed to publish to npm.
+          > Please review the [workflow logs](WORKFLOW_URL) and address any issues before attempting to publish again.
+          ---
+          EOF
+          # Replace placeholder with actual workflow URL
+          sed -i "s|WORKFLOW_URL|${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|g" release_body.txt
+          # Append original body
+          echo "$ORIGINAL_BODY" >> release_body.txt
+          # Convert to JSON string and update release
+          BODY_JSON=$(jq -Rs '.' < release_body.txt)
+          response=$(curl -s -X PATCH \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            https://api.github.com/repos/${{ github.repository }}/releases/$RELEASE_ID \
+            -d "{\"draft\": true, \"body\": ${BODY_JSON}}")
+          if echo "$response" | jq -e '.id' > /dev/null; then
+            echo "✅ Release reverted to draft with original notes preserved"
+          else
+            echo "⚠️  Warning: Failed to update release"
+            echo "$response" | jq '.'
+          fi


### PR DESCRIPTION
Update the npm publish workflow to grant write permissions for contents and add failure handling that reverts a release to draft status if the publishing fails.