### PR TITLE
Widen saveMessages content type to MessageContent

### DIFF
--- a/src/dialogue/class.dialogue.ts
+++ b/src/dialogue/class.dialogue.ts
@@ -4,6 +4,7 @@ import {
   CreateDialogueInput,
   CreateMessageInput,
   ListMessageFilters,
+  MessageContent,
 } from "@/types";
 import * as dialogueApi from "@/api/dialogue";
 import * as messageApi from "@/api/message";
@@ -288,7 +289,9 @@ export class Dialogue {
   async saveMessages(
     messages: Array<{
       role: string;
-      content: string;
+      // string | object | object[], matching saveMessage
+      // (CreateMessageInput.content) and what the API accepts.
+      content: MessageContent;
       id?: string;
       created?: string;
     }>


### PR DESCRIPTION
## Summary

Widens `Dialogue.saveMessages`' message `content` type from `string` to `MessageContent` (`string | object | object[]`), matching the singular `saveMessage` (`CreateMessageInput.content`) and what the API already accepts.

## Why

`saveMessages` was the only place typing content as `string`. The Vercel AI SDK's `response.messages` carry `content` as an array of parts, so the documented integration one-liner `dialogue.saveMessages(response.messages)` failed to compile with `TS2345` even though it works at runtime. This is the type-only gap flagged on the Vercel AI SDK integration page (dialoguedb/website#507).

## Verification

- Non-breaking: `string` is still assignable to `MessageContent`, so existing callers are unaffected.
- The internal `messagesApi.create` already accepts `Omit<CreateMessageInput, "dialogueId">[]` (content: `MessageContent`), so no downstream type change is needed.
- Verified live against the API: structured array content and the `tool` role are accepted and returned unchanged on reload.

With this, `saveMessages(response.messages)` compiles as shown on the integration page, no helper needed.
